### PR TITLE
Update alternatives hash shape for split version 3.4.1

### DIFF
--- a/lib/builder/version.rb
+++ b/lib/builder/version.rb
@@ -1,3 +1,3 @@
 module SplitBuilder
-  VERSION = "0.0.1".freeze
+  VERSION = "0.1.0".freeze
 end

--- a/lib/split-builder.rb
+++ b/lib/split-builder.rb
@@ -31,8 +31,7 @@ module SplitBuilder
   def dump_alternatives(alternatives)
     alternatives.map do |options|
       {
-        :name => options.fetch(:name).to_s,
-        :percent => options.fetch(:percent, 50)
+        options.fetch(:name).to_s => options.fetch(:percent, 50),
       }
     end
   end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -30,9 +30,10 @@ describe SplitBuilder::Schema do
 
       experiment :purchase_button_color do
         metric :any_purchase
-        alternative "green", :percent => 5
-        alternative "blue", :percent => 3
-        alternative "red", :percent => 1
+        # Use Symbols to prove they get converted to Strings.
+        alternative :green, :percent => 5
+        alternative :blue, :percent => 3
+        alternative :red, :percent => 1
       end
 
       experiment :profile_version do
@@ -51,8 +52,8 @@ describe SplitBuilder::Schema do
         :metric => :sign_in,
         :goals => ["sign_up", "sign_in"],
         :alternatives => [
-          { :name => "Get Started Today!", :percent => 75 },
-          { :name => "Sign Up", :percent => 25 }
+          { "Get Started Today!" => 75 },
+          { "Sign Up" => 25 }
         ],
         :resettable => false
       },
@@ -60,9 +61,9 @@ describe SplitBuilder::Schema do
         :metric => :any_purchase,
         :goals => ["one_time_purchase", "subscription_purchase"],
         :alternatives => [
-          { :name => "green", :percent => 5 },
-          { :name => "blue", :percent => 3 },
-          { :name => "red", :percent => 1 }
+          { "green" => 5 },
+          { "blue" => 3 },
+          { "red" => 1 }
         ],
         :resettable => false
       },
@@ -70,9 +71,9 @@ describe SplitBuilder::Schema do
         :metric => :enter_profile_information,
         :goals => ["enter_profile_information"],
         :alternatives => [
-          { :name => "none", :percent => 50 },
-          { :name => "simple", :percent => 50 },
-          { :name => "advanced", :percent => 50 }
+          { "none" => 50 },
+          { "simple" => 50 },
+          { "advanced" => 50 }
         ],
         :resettable => false
       }

--- a/split-builder.gemspec
+++ b/split-builder.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "pry", "~>0.10"
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", ">= 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
Should solve the 500 internal server error issue when visiting split dashboard in production

```
production [27] Vydia(main)> app.req.env["sinatra.error"]
=> #<ArgumentError: Alternative must be a string>
production [28] Vydia(main)> app.req.env["sinatra.error"].backtrace
=> ["/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/alternative.rb:163:in `validate!'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/experiment.rb:103:in `block in validate!'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/experiment.rb:103:in `each'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/experiment.rb:103:in `validate!'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/experiment.rb:84:in `save'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/experiment.rb:313:in `estimate_winning_alternative'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/experiment.rb:281:in `block in calc_winning_alternatives'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/experiment.rb:280:in `each'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/experiment.rb:280:in `calc_winning_alternatives'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/dashboard/views/_experiment.erb:7:in `__tilt_59320'",
 "/usr/local/bundle/ruby/3.0.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `call'",
 "/usr/local/bundle/ruby/3.0.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `evaluate'",
 "/usr/local/bundle/ruby/3.0.0/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'",
 "/usr/local/bundle/ruby/3.0.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:854:in `render'",
 "/usr/local/bundle/ruby/3.0.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:702:in `erb'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/dashboard/views/index.erb:15:in `block (2 levels) in __tilt_59320'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/dashboard/views/index.erb:14:in `each'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/dashboard/views/index.erb:14:in `block in __tilt_59320'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/dashboard/views/index.erb:9:in `each'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/dashboard/views/index.erb:9:in `__tilt_59320'",
 "/usr/local/bundle/ruby/3.0.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `call'",
 "/usr/local/bundle/ruby/3.0.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `evaluate'",
 "/usr/local/bundle/ruby/3.0.0/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'",
 "/usr/local/bundle/ruby/3.0.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:854:in `render'",
 "/usr/local/bundle/ruby/3.0.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:702:in `erb'",
 "/usr/local/bundle/ruby/3.0.0/bundler/gems/split-47d186568b17/lib/split/dashboard.rb:32:in `block in <class:Dashboard>'",
 "/usr/local/bundle/ruby/3.0.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1675:in `call'",
 "/usr/local/bundle/ruby/3.0.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1675:in `block in compile!'",
 "/usr/local/bundle/ruby/3.0.0/gems/sinatra-2.1.0/lib/sinatra/base.rb:1013:in `block (3 levels) in route!'",
```